### PR TITLE
[release 3.5.5] 依存関係の更新と、依存関係バージョン管理システムの導入

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jinbe-main_for_koyeb",
-	"version": "3.5.4",
+	"version": "3.5.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jinbe-main_for_koyeb",
-			"version": "3.5.4",
+			"version": "3.5.5",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry/node": "^10.48.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,23 +9,23 @@
 			"version": "3.5.4",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/node": "^10.47.0",
-				"@sentry/profiling-node": "^10.47.0",
+				"@sentry/node": "^10.48.0",
+				"@sentry/profiling-node": "^10.48.0",
 				"date-fns-timezone": "^0.1.4",
-				"discord.js": "^14.26.0",
-				"dotenv": "^17.4.0",
+				"discord.js": "^14.26.2",
+				"dotenv": "^17.4.1",
 				"express": "^5.2.1",
-				"mongoose": "^9.3.3",
+				"mongoose": "^9.4.1",
 				"node-cron": "^4.2.1",
 				"node-fetch": "^3.3.2"
 			},
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
-				"eslint": "^10.1.0",
+				"eslint": "^10.2.0",
 				"eslint-config-prettier": "^10.1.8",
 				"fs": "^0.0.1-security",
 				"globals": "^17.4.0",
-				"prettier": "^3.8.1"
+				"prettier": "^3.8.2"
 			}
 		},
 		"node_modules/@discordjs/builders": {
@@ -211,13 +211,13 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.23.3",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-			"integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^3.0.3",
+				"@eslint/object-schema": "^3.0.5",
 				"debug": "^4.3.1",
 				"minimatch": "^10.2.4"
 			},
@@ -226,22 +226,22 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-			"integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+			"integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.1"
+				"@eslint/core": "^1.2.1"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-			"integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -273,9 +273,9 @@
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-			"integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -283,13 +283,13 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-			"integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+			"integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.1",
+				"@eslint/core": "^1.2.1",
 				"levn": "^0.4.1"
 			},
 			"engines": {
@@ -530,23 +530,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.214.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/instrumentation-express": {
-			"version": "0.62.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.62.0.tgz",
-			"integrity": "sha512-Tvx+vgAZKEQxU3Rx+xWLiR0mLxHwmk69/8ya04+VsV9WYh8w6Lhx5hm5yAMvo1wy0KqWgFKBLwSeo3sHCwdOww==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.214.0",
-				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -1022,18 +1005,18 @@
 			}
 		},
 		"node_modules/@sentry/core": {
-			"version": "10.47.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.47.0.tgz",
-			"integrity": "sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==",
+			"version": "10.48.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
+			"integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@sentry/node": {
-			"version": "10.47.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.47.0.tgz",
-			"integrity": "sha512-R+btqPepv88o635G6HtVewLjqCLUedBg5HBs7Nq1qbbKvyti01uArUF2f+3DsLenk5B9LUNiRlE+frZA44Ahmw==",
+			"version": "10.48.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.48.0.tgz",
+			"integrity": "sha512-MzyLJyYmr0Qg60K6NJ2EdwJUX1OuAYXs9tyYxnqVO3nJ8MyYwIcuN4FCYEnXkG6Jiy/4q7OuZgXWnfdQJVcaqw==",
 			"license": "MIT",
 			"dependencies": {
 				"@fastify/otel": "0.18.0",
@@ -1044,7 +1027,6 @@
 				"@opentelemetry/instrumentation-amqplib": "0.61.0",
 				"@opentelemetry/instrumentation-connect": "0.57.0",
 				"@opentelemetry/instrumentation-dataloader": "0.31.0",
-				"@opentelemetry/instrumentation-express": "0.62.0",
 				"@opentelemetry/instrumentation-fs": "0.33.0",
 				"@opentelemetry/instrumentation-generic-pool": "0.57.0",
 				"@opentelemetry/instrumentation-graphql": "0.62.0",
@@ -1067,9 +1049,9 @@
 				"@opentelemetry/sdk-trace-base": "^2.6.1",
 				"@opentelemetry/semantic-conventions": "^1.40.0",
 				"@prisma/instrumentation": "7.6.0",
-				"@sentry/core": "10.47.0",
-				"@sentry/node-core": "10.47.0",
-				"@sentry/opentelemetry": "10.47.0",
+				"@sentry/core": "10.48.0",
+				"@sentry/node-core": "10.48.0",
+				"@sentry/opentelemetry": "10.48.0",
 				"import-in-the-middle": "^3.0.0"
 			},
 			"engines": {
@@ -1077,13 +1059,13 @@
 			}
 		},
 		"node_modules/@sentry/node-core": {
-			"version": "10.47.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.47.0.tgz",
-			"integrity": "sha512-qv6LsqHbkQmd0aQEUox/svRSz26J+l4gGjFOUNEay2armZu9XLD+Ct89jpFgZD5oIPNAj2jraodTRqydXiwS5w==",
+			"version": "10.48.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.48.0.tgz",
+			"integrity": "sha512-D1TnPhN6vhrRqJ+bN+rdXDM+INibI6lNBm0eGx45zz7DBx9ouq2e9gm/DPx+y/hAkYYq0qTd6x84cGxtVZbKLw==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "10.47.0",
-				"@sentry/opentelemetry": "10.47.0",
+				"@sentry/core": "10.48.0",
+				"@sentry/opentelemetry": "10.48.0",
 				"import-in-the-middle": "^3.0.0"
 			},
 			"engines": {
@@ -1127,12 +1109,12 @@
 			}
 		},
 		"node_modules/@sentry/opentelemetry": {
-			"version": "10.47.0",
-			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.47.0.tgz",
-			"integrity": "sha512-f6Hw2lrpCjlOksiosP0Z2jK/+l+21SIdoNglVeG/sttMyx8C8ywONKh0Ha50sFsvB1VaB8n94RKzzf3hkh9V3g==",
+			"version": "10.48.0",
+			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.48.0.tgz",
+			"integrity": "sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "10.47.0"
+				"@sentry/core": "10.48.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -1146,14 +1128,14 @@
 			}
 		},
 		"node_modules/@sentry/profiling-node": {
-			"version": "10.47.0",
-			"resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.47.0.tgz",
-			"integrity": "sha512-1xZNNWd5z7yR3Ljh0xlrydZXAgzrbqsHadtUca05ptbuBe8yXF5i0XK3FOMmXQGXh625ZnP+VO5fZIqSUEOwhA==",
+			"version": "10.48.0",
+			"resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.48.0.tgz",
+			"integrity": "sha512-eX+z1x4PPdooOfDz94c2cPrdh4rK/uxOACgpHf8qIjyiUcz1sw3l5+rNL7Ak7NZC4Ti8IvdDa7/9pH1ic+JaKw==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry-internal/node-cpu-profiler": "^2.2.0",
-				"@sentry/core": "10.47.0",
-				"@sentry/node": "10.47.0"
+				"@sentry/core": "10.48.0",
+				"@sentry/node": "10.48.0"
 			},
 			"bin": {
 				"sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
@@ -1202,12 +1184,12 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.18.0"
+				"undici-types": "~7.19.0"
 			}
 		},
 		"node_modules/@types/pg": {
@@ -1439,9 +1421,9 @@
 			"license": "MIT"
 		},
 		"node_modules/content-disposition": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-			"integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -1564,21 +1546,21 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.38.44",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.44.tgz",
-			"integrity": "sha512-q91MgBzP/gRaCLIbQTaOrOhbD8uVIaPKxpgX2sfFB2nZ9nSiTYM9P3NFQ7cbO6NCxctI6ODttc67MI+YhIfILg==",
+			"version": "0.38.45",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.45.tgz",
+			"integrity": "sha512-DiI01i00FPv6n+hXcFkFxK8Y/rFRpKs6U6aP32N4T73nTbj37Eua3H/95TBpLktLWB6xnLXhYDGvyLq6zzYY2w==",
 			"license": "MIT",
 			"workspaces": [
 				"scripts/actions/documentation"
 			]
 		},
 		"node_modules/discord.js": {
-			"version": "14.26.0",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.0.tgz",
-			"integrity": "sha512-I+5dmdg7WnjIOEXspX6mJ4jLgblhZV6QpQcC3U2JjrFWnHCKDpoLkhV46SBP8k9QePs3YWJOvndVutUARRO0AQ==",
+			"version": "14.26.2",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.2.tgz",
+			"integrity": "sha512-feShi+gULJ6R2MAA4/KkCFnkJcuVrROJrKk4czplzq8gE1oqhqgOy9K0Scu44B8oGeWKe04egquzf+ia6VtXAw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@discordjs/builders": "^1.14.0",
+				"@discordjs/builders": "^1.14.1",
 				"@discordjs/collection": "1.5.3",
 				"@discordjs/formatters": "^0.6.2",
 				"@discordjs/rest": "^2.6.1",
@@ -1600,9 +1582,9 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.4.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
-			"integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+			"version": "17.4.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+			"integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
@@ -1690,18 +1672,18 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
-			"integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+			"integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
-				"@eslint/config-array": "^0.23.3",
-				"@eslint/config-helpers": "^0.5.3",
-				"@eslint/core": "^1.1.1",
-				"@eslint/plugin-kit": "^0.6.1",
+				"@eslint/config-array": "^0.23.4",
+				"@eslint/config-helpers": "^0.5.4",
+				"@eslint/core": "^1.2.0",
+				"@eslint/plugin-kit": "^0.7.0",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
@@ -2222,9 +2204,9 @@
 			}
 		},
 		"node_modules/import-in-the-middle": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz",
-			"integrity": "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+			"integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"acorn": "^8.15.0",
@@ -2527,9 +2509,9 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "9.3.3",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.3.3.tgz",
-			"integrity": "sha512-sfv5LOIPWeN5o/281kp4Rx9ZnuXb0g8CtvBTi7trYQs2PYYx8LWXegXxG3ar7VEns1o+d4h9LI/Dtc7dTTyYmA==",
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.4.1.tgz",
+			"integrity": "sha512-4rFBWa+/wdBQSfvnOPJBpiSG6UCEbhSQh865dEdaH9Y8WfHBUC+I2XT28dp0IBIGrEwmh+gzrgZgea5PbmrHWA==",
 			"license": "MIT",
 			"dependencies": {
 				"kareem": "3.2.0",
@@ -2849,9 +2831,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+			"integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -2887,9 +2869,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-			"integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+			"version": "6.15.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -3066,13 +3048,13 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3227,9 +3209,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
 			"license": "MIT"
 		},
 		"node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"version": "3.5.5",
 	"description": "",
 	"main": "index.js",
+	"engines": {
+		"node": ">=24"
+	},
 	"scripts": {
 		"main": "node index.js && npm run sentry:sourcemaps",
 		"sentry:sourcemaps": "sentry-cli sourcemaps inject --org planet-bot-project --project jinbe-dev ./ && sentry-cli sourcemaps upload --org planet-bot-project --project jinbe-dev ./",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jinbe-main_for_koyeb",
-	"version": "3.5.4",
+	"version": "3.5.5",
 	"description": "",
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "jinbe-main_for_koyeb",
 	"version": "3.5.4",
-	"description": "```\r npm i @types/node date-fns-timezone discord.js fs mongoose node-cron node-fetch dotenv express\r ```\r ## 各パッケージの使用用途\r - `@types/node`　：node.jsを書きやすくするやつらしい\r - `date-fns-timezone`　：日本時間の月・日を取得するため\r - `discord.js`　：Discord BOTに接続し、操作するため\r - `fs` :「commands」フォルダを読み取るため\r - `mongoose` ：MongoDBの操作を簡単に行うため\r - `node-cron` ：毎日決まった時間に処理を行うため\r - `node-fetch` :URLチェックのリクエストを送るため\r - `dotenv` :環境変数を取得するため\r - `express` :ステータスチェック用のwebサーバーを立ち上げるため。",
+	"description": "",
 	"main": "index.js",
 	"scripts": {
 		"main": "node index.js && npm run sentry:sourcemaps",

--- a/package.json
+++ b/package.json
@@ -24,22 +24,22 @@
 	},
 	"homepage": "https://github.com/mcee-jinbe/main_for_koyeb#readme",
 	"dependencies": {
-		"@sentry/node": "^10.47.0",
-		"@sentry/profiling-node": "^10.47.0",
+		"@sentry/node": "^10.48.0",
+		"@sentry/profiling-node": "^10.48.0",
 		"date-fns-timezone": "^0.1.4",
-		"discord.js": "^14.26.0",
-		"dotenv": "^17.4.0",
+		"discord.js": "^14.26.2",
+		"dotenv": "^17.4.1",
 		"express": "^5.2.1",
-		"mongoose": "^9.3.3",
+		"mongoose": "^9.4.1",
 		"node-cron": "^4.2.1",
 		"node-fetch": "^3.3.2"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
-		"eslint": "^10.1.0",
+		"eslint": "^10.2.0",
 		"eslint-config-prettier": "^10.1.8",
 		"fs": "^0.0.1-security",
 		"globals": "^17.4.0",
-		"prettier": "^3.8.1"
+		"prettier": "^3.8.2"
 	}
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"],
+	"separateMultipleMajor": false,
+	"packageRules": [
+		{
+			"matchPackageNames": ["*"],
+			"automerge": false
+		}
+	],
+	"schedule": ["before 4am"],
+	"assignees": ["Hoshimikan6490"],
+	"prConcurrentLimit": 0,
+	"prHourlyLimit": 0,
+	"timezone": "Asia/Tokyo"
+}


### PR DESCRIPTION
This pull request mainly updates dependencies to their latest versions and introduces a new configuration file for Renovate, which will help automate dependency management. The most important changes are summarized below:

Dependency updates:

* Updated several dependencies in `package.json` to their latest patch/minor versions, including `@sentry/node`, `@sentry/profiling-node`, `discord.js`, `dotenv`, `mongoose`, `eslint`, and `prettier`.
* Bumped the project version from `3.5.4` to `3.5.5` and cleared the `description` field in `package.json`.

Tooling and automation:

* Added a new `renovate.json` configuration file to enable and customize Renovate bot for automated dependency update PRs, with settings for scheduling, assignees, and PR limits.