### PR TITLE
[release 3.5.6] 依存関係の更新と、プロジェクト名の変更に伴う変更

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -81,7 +81,7 @@ module.exports = {
 					new ButtonBuilder()
 						.setStyle(ButtonStyle.Link)
 						.setLabel('このBOTのコードを見る')
-						.setURL('https://github.com/mcee-jinbe/main_for_koyeb'),
+						.setURL('https://github.com/HoshimiTech/JINBE'),
 				);
 
 				return interaction.editReply({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jinbe",
-	"version": "3.5.5",
+	"version": "3.5.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jinbe",
-			"version": "3.5.5",
+			"version": "3.5.6",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry/node": "^10.49.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "jinbe-main_for_koyeb",
+	"name": "jinbe",
 	"version": "3.5.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "jinbe-main_for_koyeb",
+			"name": "jinbe",
 			"version": "3.5.5",
 			"license": "MIT",
 			"dependencies": {
@@ -26,6 +26,9 @@
 				"fs": "^0.0.1-security",
 				"globals": "^17.4.0",
 				"prettier": "^3.8.2"
+			},
+			"engines": {
+				"node": ">=24"
 			}
 		},
 		"node_modules/@discordjs/builders": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
 			"version": "3.5.5",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/node": "^10.48.0",
-				"@sentry/profiling-node": "^10.48.0",
+				"@sentry/node": "^10.49.0",
+				"@sentry/profiling-node": "^10.49.0",
 				"date-fns-timezone": "^0.1.4",
-				"discord.js": "^14.26.2",
-				"dotenv": "^17.4.1",
+				"discord.js": "^14.26.3",
+				"dotenv": "^17.4.2",
 				"express": "^5.2.1",
 				"mongoose": "^9.4.1",
 				"node-cron": "^4.2.1",
@@ -24,8 +24,8 @@
 				"eslint": "^10.2.0",
 				"eslint-config-prettier": "^10.1.8",
 				"fs": "^0.0.1-security",
-				"globals": "^17.4.0",
-				"prettier": "^3.8.2"
+				"globals": "^17.5.0",
+				"prettier": "^3.8.3"
 			},
 			"engines": {
 				"node": ">=24"
@@ -418,9 +418,9 @@
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
-			"integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.8.tgz",
+			"integrity": "sha512-kpjr2jy2w71w0oqAMI8oibBmiF9lXxWkEQs5gMkW4hVE48bsqINGLxnCSYW62ck/NHXJQpQEfA9WlJ1sY0eqBg==",
 			"license": "MIT",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
@@ -447,22 +447,10 @@
 				"node": ">=8.0.0"
 			}
 		},
-		"node_modules/@opentelemetry/context-async-hooks": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
-			"integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
 		"node_modules/@opentelemetry/core": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-			"integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+			"integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -620,6 +608,21 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+			"integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-ioredis": {
@@ -851,12 +854,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-			"integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
+			"integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.6.1",
+				"@opentelemetry/core": "2.7.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -867,13 +870,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
-			"integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
+			"integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.6.1",
-				"@opentelemetry/resources": "2.6.1",
+				"@opentelemetry/core": "2.7.0",
+				"@opentelemetry/resources": "2.7.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -1008,23 +1011,22 @@
 			}
 		},
 		"node_modules/@sentry/core": {
-			"version": "10.48.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
-			"integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
+			"version": "10.49.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.49.0.tgz",
+			"integrity": "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@sentry/node": {
-			"version": "10.48.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.48.0.tgz",
-			"integrity": "sha512-MzyLJyYmr0Qg60K6NJ2EdwJUX1OuAYXs9tyYxnqVO3nJ8MyYwIcuN4FCYEnXkG6Jiy/4q7OuZgXWnfdQJVcaqw==",
+			"version": "10.49.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.49.0.tgz",
+			"integrity": "sha512-xr+HXABCiO5mgAJRQxsXRdNOLO0+Ee6CvXAAIqovL2A1GlhxNWc5ooPWeIrrLDJ/KGyT8zI91O5scpVXdXs0uQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@fastify/otel": "0.18.0",
 				"@opentelemetry/api": "^1.9.1",
-				"@opentelemetry/context-async-hooks": "^2.6.1",
 				"@opentelemetry/core": "^2.6.1",
 				"@opentelemetry/instrumentation": "^0.214.0",
 				"@opentelemetry/instrumentation-amqplib": "0.61.0",
@@ -1048,13 +1050,12 @@
 				"@opentelemetry/instrumentation-redis": "0.62.0",
 				"@opentelemetry/instrumentation-tedious": "0.33.0",
 				"@opentelemetry/instrumentation-undici": "0.24.0",
-				"@opentelemetry/resources": "^2.6.1",
 				"@opentelemetry/sdk-trace-base": "^2.6.1",
 				"@opentelemetry/semantic-conventions": "^1.40.0",
 				"@prisma/instrumentation": "7.6.0",
-				"@sentry/core": "10.48.0",
-				"@sentry/node-core": "10.48.0",
-				"@sentry/opentelemetry": "10.48.0",
+				"@sentry/core": "10.49.0",
+				"@sentry/node-core": "10.49.0",
+				"@sentry/opentelemetry": "10.49.0",
 				"import-in-the-middle": "^3.0.0"
 			},
 			"engines": {
@@ -1062,13 +1063,13 @@
 			}
 		},
 		"node_modules/@sentry/node-core": {
-			"version": "10.48.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.48.0.tgz",
-			"integrity": "sha512-D1TnPhN6vhrRqJ+bN+rdXDM+INibI6lNBm0eGx45zz7DBx9ouq2e9gm/DPx+y/hAkYYq0qTd6x84cGxtVZbKLw==",
+			"version": "10.49.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.49.0.tgz",
+			"integrity": "sha512-7WO0KuCDPSq3G54TVUSI1CKFJwB67LasG+n/gDMBqbrarzs/Yh/s34OOMU5gfVQpncxQAmQsy4nEboQms8iNqA==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "10.48.0",
-				"@sentry/opentelemetry": "10.48.0",
+				"@sentry/core": "10.49.0",
+				"@sentry/opentelemetry": "10.49.0",
 				"import-in-the-middle": "^3.0.0"
 			},
 			"engines": {
@@ -1076,19 +1077,14 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
 				"@opentelemetry/core": "^1.30.1 || ^2.1.0",
 				"@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
 				"@opentelemetry/instrumentation": ">=0.57.1 <1",
-				"@opentelemetry/resources": "^1.30.1 || ^2.1.0",
 				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
 				"@opentelemetry/semantic-conventions": "^1.39.0"
 			},
 			"peerDependenciesMeta": {
 				"@opentelemetry/api": {
-					"optional": true
-				},
-				"@opentelemetry/context-async-hooks": {
 					"optional": true
 				},
 				"@opentelemetry/core": {
@@ -1100,9 +1096,6 @@
 				"@opentelemetry/instrumentation": {
 					"optional": true
 				},
-				"@opentelemetry/resources": {
-					"optional": true
-				},
 				"@opentelemetry/sdk-trace-base": {
 					"optional": true
 				},
@@ -1112,33 +1105,32 @@
 			}
 		},
 		"node_modules/@sentry/opentelemetry": {
-			"version": "10.48.0",
-			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.48.0.tgz",
-			"integrity": "sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A==",
+			"version": "10.49.0",
+			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.49.0.tgz",
+			"integrity": "sha512-XNLm4dXmtegXQf+EEE2Cs84Ymlo/f5wMx+lg2S2XS4qLbXaPN/HttjhwKftd8D+8iUNfmH+xNMCSshx4s1B/1w==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "10.48.0"
+				"@sentry/core": "10.49.0"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
 				"@opentelemetry/core": "^1.30.1 || ^2.1.0",
 				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
 				"@opentelemetry/semantic-conventions": "^1.39.0"
 			}
 		},
 		"node_modules/@sentry/profiling-node": {
-			"version": "10.48.0",
-			"resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.48.0.tgz",
-			"integrity": "sha512-eX+z1x4PPdooOfDz94c2cPrdh4rK/uxOACgpHf8qIjyiUcz1sw3l5+rNL7Ak7NZC4Ti8IvdDa7/9pH1ic+JaKw==",
+			"version": "10.49.0",
+			"resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.49.0.tgz",
+			"integrity": "sha512-58VoaCsn5TnQ+RDD5JY2omBESTYOOJYnqQedzI4poRia9flWMtN29rwvMOOpFoY94dz/cOrsakG1oAq8u9LpMA==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry-internal/node-cpu-profiler": "^2.2.0",
-				"@sentry/core": "10.48.0",
-				"@sentry/node": "10.48.0"
+				"@sentry/core": "10.49.0",
+				"@sentry/node": "10.49.0"
 			},
 			"bin": {
 				"sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
@@ -1549,18 +1541,18 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.38.45",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.45.tgz",
-			"integrity": "sha512-DiI01i00FPv6n+hXcFkFxK8Y/rFRpKs6U6aP32N4T73nTbj37Eua3H/95TBpLktLWB6xnLXhYDGvyLq6zzYY2w==",
+			"version": "0.38.47",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.47.tgz",
+			"integrity": "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==",
 			"license": "MIT",
 			"workspaces": [
 				"scripts/actions/documentation"
 			]
 		},
 		"node_modules/discord.js": {
-			"version": "14.26.2",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.2.tgz",
-			"integrity": "sha512-feShi+gULJ6R2MAA4/KkCFnkJcuVrROJrKk4czplzq8gE1oqhqgOy9K0Scu44B8oGeWKe04egquzf+ia6VtXAw==",
+			"version": "14.26.3",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.3.tgz",
+			"integrity": "sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@discordjs/builders": "^1.14.1",
@@ -1585,9 +1577,9 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.4.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-			"integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
@@ -2112,9 +2104,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "17.4.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-			"integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+			"version": "17.5.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+			"integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2834,9 +2826,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-			"integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "jinbe-main_for_koyeb",
+	"name": "jinbe",
 	"version": "3.5.5",
 	"description": "",
 	"main": "index.js",
@@ -27,11 +27,11 @@
 	},
 	"homepage": "https://github.com/HoshimiTech/JINBE#readme",
 	"dependencies": {
-		"@sentry/node": "^10.48.0",
-		"@sentry/profiling-node": "^10.48.0",
+		"@sentry/node": "^10.49.0",
+		"@sentry/profiling-node": "^10.49.0",
 		"date-fns-timezone": "^0.1.4",
-		"discord.js": "^14.26.2",
-		"dotenv": "^17.4.1",
+		"discord.js": "^14.26.3",
+		"dotenv": "^17.4.2",
 		"express": "^5.2.1",
 		"mongoose": "^9.4.1",
 		"node-cron": "^4.2.1",
@@ -42,7 +42,7 @@
 		"eslint": "^10.2.0",
 		"eslint-config-prettier": "^10.1.8",
 		"fs": "^0.0.1-security",
-		"globals": "^17.4.0",
-		"prettier": "^3.8.2"
+		"globals": "^17.5.0",
+		"prettier": "^3.8.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"main": "node index.js && npm run sentry:sourcemaps",
-		"sentry:sourcemaps": "sentry-cli sourcemaps inject --org planet-bot-project --project jinbe-dev ./ && sentry-cli sourcemaps upload --org planet-bot-project --project jinbe-dev ./",
+		"sentry:sourcemaps": "sentry-cli sourcemaps inject --org hoshimitech --project jinbe-dev ./ && sentry-cli sourcemaps upload --org hoshimitech --project jinbe-dev ./",
 		"buildTest": "docker image build --tag jinbe-dev:latest . && docker run --name jinbe-dev --rm jinbe-dev:latest",
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
@@ -18,14 +18,14 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/mcee-jinbe/main_for_koyeb.git"
+		"url": "git+https://github.com/HoshimiTech/JINBE.git"
 	},
 	"author": "Hoshimikan6490",
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/mcee-jinbe/main_for_koyeb/issues"
+		"url": "https://github.com/HoshimiTech/JINBE/issues"
 	},
-	"homepage": "https://github.com/mcee-jinbe/main_for_koyeb#readme",
+	"homepage": "https://github.com/HoshimiTech/JINBE#readme",
 	"dependencies": {
 		"@sentry/node": "^10.48.0",
 		"@sentry/profiling-node": "^10.48.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jinbe",
-	"version": "3.5.5",
+	"version": "3.5.6",
 	"description": "",
 	"main": "index.js",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"node": ">=24"
 	},
 	"scripts": {
-		"main": "node index.js && npm run sentry:sourcemaps",
+		"main": "npm run sentry:sourcemaps && node index.js",
 		"sentry:sourcemaps": "sentry-cli sourcemaps inject --org hoshimitech --project jinbe-dev ./ && sentry-cli sourcemaps upload --org hoshimitech --project jinbe-dev ./",
 		"buildTest": "docker image build --tag jinbe-dev:latest . && docker run --name jinbe-dev --rm jinbe-dev:latest",
 		"lint": "eslint .",


### PR DESCRIPTION
This pull request updates the project metadata, dependency versions, and repository links to reflect the new project location and ownership. It also updates several dependencies to their latest versions.

Project metadata and repository updates:

* Changed the project name to `jinbe` and updated the version to `3.5.6` in `package.json`.
* Updated all repository, bugs, and homepage URLs in `package.json` to point to `https://github.com/HoshimiTech/JINBE`.
* Updated the link to the bot's source code in `commands/help.js` to the new repository URL.

Dependency updates:

* Bumped versions for several dependencies in `package.json`, including `@sentry/node`, `@sentry/profiling-node`, `discord.js`, `dotenv`, `globals`, and `prettier`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-R34) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L45-R46)

Sentry configuration update:

* Changed the Sentry organization in the `sentry:sourcemaps` script to `hoshimitech`.